### PR TITLE
File path changed for compatibility with Symphony CMS 2.3.3

### DIFF
--- a/fields/field.reflectedupload.php
+++ b/fields/field.reflectedupload.php
@@ -129,7 +129,7 @@ class FieldReflectedUpload extends FieldUpload {
         $old = $abs_path . '/' . $old_filename . $file_extension;
         $new = $abs_path . '/' . $new_value;
         if (rename($old , $new)) {
-            $new_value = $rel_path . '/' . $new_value;
+            $new_value = $new_value;
             // Save:
             $result = Symphony::Database()->update(
                 array(


### PR DESCRIPTION
In Symphony CMS 2.3.3 the file must not be saved with the full path
anymore but with the filename only. With my change, the database field
„file“ now only contains the filename.
