### PR TITLE
Version 1.2 for Symphony 2.3.3+

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,9 +1,9 @@
 Field: Reflected File Upload
 ------------------------------------------------------------------------------
 
-Version: 1.1
+Version: 1.2
 Author: Simon de Turck
-Build Date: 2011-11-23
+Build Date: 2014-07-29
 Requirements: Symphony 2.3+
 
 Extension home: http://symphony-cms.com/download/extensions/view/80973/
@@ -28,6 +28,10 @@ Michael Eichelsdoerfer and the "reflection field" by Rowan Lewis.
 This field enables you to specify the naming expression using XPath (like in the reflection field). When uniqueness is important you can enable the "Always create unique name" option. This will add "Unique Upload Field" behavior by appending a unique token to the filename.
 
 [Changes]
+
+1.2
+- 2.3.3+ Compatibility (Separation of file names and file paths)
+- PHP 5.3+ Compatibility (Removed deprecated pass-by-reference arguments)
 
 1.1
 - 2.3 compatibility

--- a/extension.driver.php
+++ b/extension.driver.php
@@ -77,8 +77,22 @@ class extension_reflecteduploadfield extends Extension {
     ############################
 
     public function update($previousVersion) {
-       if(version_compare($previousVersion, '1.0','<=')){
+    	
+        if(version_compare($previousVersion, '1.0','<=')){
             Symphony::Database()->query("ALTER TABLE  `tbl_fields_reflectedupload` ADD  `unique` tinyint(1) default '0'");
+        }
+        
+        // Before 1.2
+        if (version_compare($previous_version, '1.2', '<')) {
+            // Remove directory from the upload fields, fixes Symphony Issue #1719
+            $upload_tables = Symphony::Database()->fetchCol("field_id", "SELECT `field_id` FROM `tbl_fields_reflectedupload`");
+            
+            if(is_array($upload_tables) && !empty($upload_tables)) foreach($upload_tables as $field) {
+                Symphony::Database()->query(sprintf(
+                    "UPDATE tbl_entries_data_%d SET file = substring_index(file, '/', -1)",
+                    $field
+                ));
+             }
         }
     }
 

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -2,8 +2,8 @@
 <extension id="reflecteduploadfield" status="released" xmlns="http://symphony-cms.com/schemas/extension/1.0">
 	<name>Reflected file upload</name>
 	<description>Name your files the way YOU want!</description>
-	<repo type="github">https://github.com/zimmen/reflecteduploadfield</repo>
-	<url type="discuss">http://symphony-cms.com/discuss/thread/80974/</url>
+	<repo type="github">https://github.com/TwistedInteractive/reflecteduploadfield</repo>
+	<url type="discuss">http://www.getsymphony.com/discuss/thread/80974/</url>
 	<types>
 		<type>Field</type>
 	</types>
@@ -14,6 +14,10 @@
 		</author>
 	</authors>
 	<releases>
+		<release version="1.2" date="2014-07-29" min="2.3.3">
+			* Symphony 2.3.3 compatible
+			* File Path no longer saved as part of the file name
+		</release>
 		<release version="1.1" date="2012-07-25" min="2.3.0">
 			* Symphony 2.3 compatible
 			* Fix when removing a file and not picking a new one

--- a/extension.meta.xml
+++ b/extension.meta.xml
@@ -18,7 +18,7 @@
 			* Symphony 2.3.3 compatible
 			* File Path no longer saved as part of the file name
 		</release>
-		<release version="1.1" date="2012-07-25" min="2.3.0">
+		<release version="1.1" date="2012-07-25" min="2.3.0" max="2.3.2">
 			* Symphony 2.3 compatible
 			* Fix when removing a file and not picking a new one
 		</release>

--- a/fields/field.reflectedupload.php
+++ b/fields/field.reflectedupload.php
@@ -11,8 +11,8 @@ class FieldReflectedUpload extends FieldUpload {
         $this->_name = __('Reflected File Upload');
     }
 
-    public function displaySettingsPanel(&$wrapper , $errors = null) {
-        parent::displaySettingsPanel(&$wrapper , $errors);
+    public function displaySettingsPanel($wrapper , $errors = null) {
+        parent::displaySettingsPanel($wrapper , $errors);
 
         $label = Widget::Label('Name Expression
         <i>To access the other fields, use XPath: <code>{entry/field-one} static text {entry/field-two}</code></i>');
@@ -28,7 +28,7 @@ class FieldReflectedUpload extends FieldUpload {
         $wrapper->appendChild($setting);
     }
 
-    public function checkFields(&$errors , $checkForDuplicates = true) {
+    public function checkFields($errors , $checkForDuplicates = true) {
 
         $expression = $this->get('expression');
         if (empty($expression)) {
@@ -62,12 +62,12 @@ class FieldReflectedUpload extends FieldUpload {
         return preg_replace("/([^\/]*)(\.[^\.]+)$/e" , "substr('$1', 0, $crop).'-'.uniqid().'$2'" , $filename);
     }
 
-    public function checkPostFieldData($data , &$message , $entry_id = NULL) {
+    public function checkPostFieldData($data , $message , $entry_id = NULL) {
         extension_reflecteduploadfield::registerField($this);
         return self::__OK__;
     }
 
-    public function processRawFieldData($data, &$status, &$message=null, $simulate = false, $entry_id = NULL) {
+    public function processRawFieldData($data, $status, $message=null, $simulate = false, $entry_id = NULL) {
         if (is_array($data) and isset($data['name'])) $data['name'] = $this->getUniqueFilename($data['name']);
         return parent::processRawFieldData($data, $status, $message, $simulate, $entry_id);
     }

--- a/fields/field.reflectedupload.php
+++ b/fields/field.reflectedupload.php
@@ -129,7 +129,6 @@ class FieldReflectedUpload extends FieldUpload {
         $old = $abs_path . '/' . $old_filename . $file_extension;
         $new = $abs_path . '/' . $new_value;
         if (rename($old , $new)) {
-            $new_value = $rel_path . '/' . $new_value;
             // Save:
             $result = Symphony::Database()->update(
                 array(


### PR DESCRIPTION
Makes this extension fully compatible with Symphony 2.3.3+ and includes the following changes:

 1) Removing file path from file name (according to https://github.com/symphonycms/symphony-2/issues/1719)
 2) Added update-function to perform the needed file path changes in the database.
 3) Changed deprecated pass-by-reference arguments to pass-by-value arguments (PHP 5.3+) (Fixes https://github.com/TwistedInteractive/reflecteduploadfield/issues/4)
 4) Updated Readme and Meta.